### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/zebra-admin-web/pom.xml
+++ b/zebra-admin-web/pom.xml
@@ -10,7 +10,7 @@
     <packaging>war</packaging>
 
     <properties>
-        <fastjson>1.2.29</fastjson>
+        <fastjson>1.2.83</fastjson>
     </properties>
 
     <name>zebra-admin-web</name>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alibaba:fastjson 1.2.29
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)


### What did I do？
Upgrade com.alibaba:fastjson from 1.2.29 to 1.2.83 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS